### PR TITLE
MOTR-51 add JS tests to CI, no snapshot testing, no npm cache restore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,45 +1,43 @@
 # Javascript Node CircleCI 2.0 configuration file
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
-# version: 2
-# jobs:
-#   build:
-#     docker:
-#       # specify the version you desire here
-#       - image: circleci/node:7.10
 
-#       # Specify service dependencies here if necessary
-#       # CircleCI maintains a library of pre-built images
-#       # documented at https://circleci.com/docs/2.0/circleci-images/
-#       # - image: circleci/mongo:3.4.4
-
-#     working_directory: ~/repo
-
-#     steps:
-#       - checkout
-
-#       # Download and cache dependencies
-#       - restore_cache:
-#           keys:
-#           - v1-dependencies-{{ checksum "package.json" }}
-#           # fallback to using the latest cache if no exact match is found
-#           - v1-dependencies-
-
-#       - run: yarn install
-
-#       - save_cache:
-#           paths:
-#             - node_modules
-#           key: v1-dependencies-{{ checksum "package.json" }}
-
-#       # run tests!
-#       - run: yarn test
 version: 2
 jobs:
   build:
     docker:
       - image: circleci/node:10.12-browsers
+
     steps:
       - checkout
-      - run: echo "A first hello"
+
+      - restore_cache:
+          #note: we are not currently version controlling yarn.lock so the cache restore will not work
+          #TODO: enable for production builds
+          name: Restore core JS dependencies cache
+          keys:
+            - v1-js-dependencies-{{ checksum "yarn.lock" }}
+            # uncomment to allow fallback to using the latest cache if no exact match is found
+            # - v1-dependencies-
+          paths:
+            - ~/.cache/yarn
+
+      - run:
+          name: Install JS dependencies
+          command: yarn install
+
+      - save_cache:
+          name: Cache core JS dependencies
+          key: v1-js-dependencies-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+
+      - run:
+          name: Compile CSS
+          command: node_modules/sass/sass.js src/sass/main.scss src/main.css
+
+      - run:
+          name: Run Frontend tests
+          command: yarn test --updateSnapshot --ci
+          # use this line instead if we version control snapshots
+          # command: yarn test --ci


### PR DESCRIPTION
Note: for early stage development yarn.lock is not versioned so npm/yarn package cache can't be restored. See note in file to change.

Note2: for early stage development storybook snapshots are not not version-controlled, so snapshot testing is not being done in CI. See note in file to change.