### PR TITLE
update CircleCi JS dependencies cache restore via yarn.lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ jobs:
           #TODO: enable for production builds
           name: Restore core JS dependencies cache
           keys:
-            - v1-js-dependencies-{{ checksum "yarn.lock" }}
+            # - v1-js-dependencies-{{ checksum "yarn.lock" }}
             # uncomment to allow fallback to using the latest cache if no exact match is found
-            # - v1-dependencies-
+            - v1-dependencies-
           paths:
             - ~/.cache/yarn
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,12 @@ jobs:
       - checkout
 
       - restore_cache:
-          #note: we are not currently version controlling yarn.lock so the cache restore will not work
-          #TODO: enable for production builds
           name: Restore core JS dependencies cache
           keys:
+            # TODO: enable and version control yarn.lock for production builds
+            # TODO: uncomment to explicicitly load the cache from the latest yarn.lock
             # - v1-js-dependencies-{{ checksum "yarn.lock" }}
-            # uncomment to allow fallback to using the latest cache if no exact match is found
+            # comment to prevent fallback to using the latest cache if no exact match is found
             - v1-js-dependencies-
           paths:
             - ~/.cache/yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ jobs:
           #TODO: enable for production builds
           name: Restore core JS dependencies cache
           keys:
-            # - v1-js-dependencies-{{ checksum "yarn.lock" }}
+            - v1-js-dependencies-{{ checksum "yarn.lock" }}
             # uncomment to allow fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v1-js-dependencies-
           paths:
             - ~/.cache/yarn
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           #TODO: enable for production builds
           name: Restore core JS dependencies cache
           keys:
-            - v1-js-dependencies-{{ checksum "yarn.lock" }}
+            # - v1-js-dependencies-{{ checksum "yarn.lock" }}
             # uncomment to allow fallback to using the latest cache if no exact match is found
             - v1-js-dependencies-
           paths:


### PR DESCRIPTION
 - Removing the check for `yarn.lock` in the JS dependencies cache restore because we do not use that currently and it throws a warning. 

 - Enabled fallback to restore the most current version of the JS dependencies cache since we are not versioning JS cache.

_Note: we can remove the fallback restore if it causes curious behaviors since it only saves a small amount of time right now_

_Note2: `yarn.lock` versioning will be used for production builds and the explicit yarn.lock cache can be re-enabled at that time_