### PR TITLE
MOTR-80 Refactor Auth0 Callback URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "sass-watch": "node_modules/sass/sass.js --watch src/sass/main.scss src/main.css",
     "inspect-branch": "yarn && yarn sass && yarn start"
   },
-  "proxy": "http://localhost:3001",
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/src/Auth/auth0-variables.js
+++ b/src/Auth/auth0-variables.js
@@ -1,5 +1,7 @@
-export const AUTH_CONFIG = {
+const url = new URL(window.location.href);
+
+export const AUTH0_CONFIG = {
   domain: 'motrpac-project.auth0.com',
   clientId: '4dUo4JxLlZvCtFVCw21Nh0ZRKyznluAZ',
-  callbackUrl: 'http://localhost:3000/callback'
+  callbackUrl: `${url.origin}/callback`
 };

--- a/src/Footer/footer.jsx
+++ b/src/Footer/footer.jsx
@@ -5,7 +5,14 @@ import { connect } from 'react-redux';
 import actions from '../Auth/authActions';
 
 /**
- * Method to render global footer
+ * Renders the global footer.
+ * 
+ * @param {Boolean}   isAuthenticated Redux state for user's authentication status.
+ * @param {Object}    profile         Redux state for authenticated user's info.
+ * @param {Function}  login           Redux action for user login.
+ * @param {Function}  logout          Redux action for user logout.
+ * 
+ * @returns {object} JSX representation of the global footer.
  */
 export function Footer({
   isAuthenticated,

--- a/src/Navbar/navbar.jsx
+++ b/src/Navbar/navbar.jsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
+/**
+ * Renders the global header nav bar.
+ * 
+ * @param {Boolean} isAuthenticated Redux state for user's authentication status.
+ * 
+ * @returns {Object} JSX representation of the global header nav bar.
+ */
 export function Navbar({ isAuthenticated = false }) {
   const loggedInNavItems = (
     <React.Fragment>


### PR DESCRIPTION
**Key Changes:**
1. Refactored the `callbackUrl` option in the  `auth0-variables.js` file so that it is not hardcoded to `localhost`.
2. Refactored the `Auth` class by switching to the use of `expiresAt` class variable from the local class method variables.
3. Removed unnecessary `proxy` option in `package.json`.