### PR TITLE
MOTR-168 Updated KiB/MiB/GiB to KB/MB/GB for External Release 1.0

### DIFF
--- a/src/ReleasePage/releases.json
+++ b/src/ReleasePage/releases.json
@@ -68,7 +68,7 @@
           "tooltip_id": "data-phenotype-1-0",
           "object_path": "/phenotype",
           "object_zipfile_path": "/phenotype.tar.gz",
-          "object_zipfile_size": "510 KB"
+          "object_zipfile_size": "526 KB"
         },
         {
           "type": "all",
@@ -120,7 +120,7 @@
           "tooltip_id": "data-rna-seq-1-2",
           "object_path": "/rna-seq",
           "object_zipfile_path": "/rna-seq.tar.gz",
-          "object_zipfile_size": "203 MB"
+          "object_zipfile_size": "213 MB"
         },
         {
           "type": "rrbs",
@@ -140,7 +140,7 @@
           "tooltip_id": "data-metabolomics-1-2",
           "object_path": "/metabolomics",
           "object_zipfile_path": "/metabolomics.tar.gz",
-          "object_zipfile_size": "94 MB"
+          "object_zipfile_size": "99 MB"
         },
         {
           "type": "proteomics",
@@ -150,7 +150,7 @@
           "tooltip_id": "data-proteomics-1-2",
           "object_path": "/proteomics",
           "object_zipfile_path": "/proteomics.tar.gz",
-          "object_zipfile_size": "274 MB"
+          "object_zipfile_size": "288 MB"
         },
         {
           "type": "phenotype",
@@ -170,7 +170,7 @@
           "tooltip_id": "data-all-1-2",
           "object_path": "",
           "object_zipfile_path": "/all.tar.gz",
-          "object_zipfile_size": "574 MB"
+          "object_zipfile_size": "602 MB"
         }
       ]
     },
@@ -217,7 +217,7 @@
           "tooltip_id": "data-rna-seq-1-1",
           "object_path": "/rna-seq",
           "object_zipfile_path": "/rna-seq.tar.gz",
-          "object_zipfile_size": "203 MB"
+          "object_zipfile_size": "213 MB"
         },
         {
           "type": "rrbs",
@@ -237,7 +237,7 @@
           "tooltip_id": "data-metabolomics-1-1",
           "object_path": "/metabolomics",
           "object_zipfile_path": "/metabolomics.tar.gz",
-          "object_zipfile_size": "94 MB"
+          "object_zipfile_size": "99 MB"
         },
         {
           "type": "proteomics",
@@ -247,7 +247,7 @@
           "tooltip_id": "data-proteomics-1-1",
           "object_path": "/proteomics",
           "object_zipfile_path": "/proteomics.tar.gz",
-          "object_zipfile_size": "274 MB"
+          "object_zipfile_size": "288 MB"
         },
         {
           "type": "phenotype",
@@ -257,7 +257,7 @@
           "tooltip_id": "data-phenotype-1-1",
           "object_path": "/phenotype",
           "object_zipfile_path": "/phenotype.tar.gz",
-          "object_zipfile_size": "266 KB"
+          "object_zipfile_size": "273 KB"
         },
         {
           "type": "all",
@@ -267,7 +267,7 @@
           "tooltip_id": "data-all-1-1",
           "object_path": "",
           "object_zipfile_path": "/all.tar.gz",
-          "object_zipfile_size": "572 MB"
+          "object_zipfile_size": "600 MB"
         }
       ]
     },
@@ -314,7 +314,7 @@
           "tooltip_id": "data-rna-seq-1-0",
           "object_path": "/rna-seq",
           "object_zipfile_path": "/rna-seq.tar.gz",
-          "object_zipfile_size": "203 MB"
+          "object_zipfile_size": "213 MB"
         },
         {
           "type": "rrbs",
@@ -334,7 +334,7 @@
           "tooltip_id": "data-metabolomics-1-0",
           "object_path": "/metabolomics",
           "object_zipfile_path": "/metabolomics.tar.gz",
-          "object_zipfile_size": "72 MB"
+          "object_zipfile_size": "76 MB"
         },
         {
           "type": "proteomics",
@@ -344,7 +344,7 @@
           "tooltip_id": "data-proteomics-1-0",
           "object_path": "/proteomics",
           "object_zipfile_path": "/proteomics.tar.gz",
-          "object_zipfile_size": "218 MB"
+          "object_zipfile_size": "229 MB"
         },
         {
           "type": "phenotype",
@@ -354,7 +354,7 @@
           "tooltip_id": "data-phenotype-1-0",
           "object_path": "/phenotype",
           "object_zipfile_path": "/phenotype.tar.gz",
-          "object_zipfile_size": "266 KB"
+          "object_zipfile_size": "273 KB"
         },
         {
           "type": "all",
@@ -364,7 +364,7 @@
           "tooltip_id": "data-all-1-0",
           "object_path": "",
           "object_zipfile_path": "/all.tar.gz",
-          "object_zipfile_size": "494 MB"
+          "object_zipfile_size": "518 MB"
         }
       ]
     },

--- a/src/ReleasePage/releases.json
+++ b/src/ReleasePage/releases.json
@@ -18,7 +18,7 @@
           "tooltip_id": "data-epigenomics-1-0",
           "object_path": "/epigenomics",
           "object_zipfile_path": "/epigenomics.tar.gz",
-          "object_zipfile_size": "8 GB"
+          "object_zipfile_size": "9 GB"
         },
         {
           "type": "transcriptomics",
@@ -28,7 +28,7 @@
           "tooltip_id": "data-transcriptomics-1-0",
           "object_path": "/transcriptomics",
           "object_zipfile_path": "/transcriptomics.tar.gz",
-          "object_zipfile_size": "50 MB"
+          "object_zipfile_size": "53 MB"
         },
         {
           "type": "metabolomics_targeted",
@@ -38,7 +38,7 @@
           "tooltip_id": "data-metabolomics_targeted-1-0",
           "object_path": "/metabolomics_targeted",
           "object_zipfile_path": "/metabolomics_targeted.tar.gz",
-          "object_zipfile_size": "22 MB"
+          "object_zipfile_size": "23 MB"
         },
         {
           "type": "metabolomics_untargeted",
@@ -48,7 +48,7 @@
           "tooltip_id": "data-metabolomics_untargeted-1-0",
           "object_path": "/metabolomics_untargeted",
           "object_zipfile_path": "/metabolomics_untargeted.tar.gz",
-          "object_zipfile_size": "96 MB"
+          "object_zipfile_size": "101 MB"
         },
         {
           "type": "proteomics",
@@ -58,7 +58,7 @@
           "tooltip_id": "data-proteomics-1-0",
           "object_path": "/proteomics",
           "object_zipfile_path": "/proteomics.tar.gz",
-          "object_zipfile_size": "284 MB"
+          "object_zipfile_size": "298 MB"
         },
         {
           "type": "phenotype",
@@ -68,7 +68,7 @@
           "tooltip_id": "data-phenotype-1-0",
           "object_path": "/phenotype",
           "object_zipfile_path": "/phenotype.tar.gz",
-          "object_zipfile_size": "498 KB"
+          "object_zipfile_size": "510 KB"
         },
         {
           "type": "all",


### PR DESCRIPTION
**Key Change**
- Updated file sizes from KiB/MiB/GiB to KB/MB/GB for downloads in the external release v1.0

**Calculations**
As I did not have view access to motrpac-external-release1-results via gsutil, I asked Young to send me a screenshot from the console and calculated based off of that:
![image](https://user-images.githubusercontent.com/29579769/66856314-ce9bc480-ef39-11e9-8c04-d06a0ffb20a6.png)

- Epigenomics
8.28 GiB = 8.89 GB -> 9 GB

- Transcriptomics
50.3 MiB = 52.74 -> 53 MB

- Metabolomics Targeted
21.48 MiB = 22.52 -> 23 MB

- Metabolomics Untargeted
96.29 MiB = 100.97 MB -> 101 MB

- Proteomics
283.73 MiB = 297.51 MB -> 298 MB

- Phenotype
497.56 KiB = 509.50 KB -> 510 KB

- All
8.73 GiB = 9.37 GB -> 9 GB