### PR TITLE
MOTR-196 MOTR-199 MOTR-201

### DIFF
--- a/src/ErrorPage/error.jsx
+++ b/src/ErrorPage/error.jsx
@@ -20,17 +20,36 @@ export function ErrorPage({ isAuthenticated, profile }) {
     <div className="col-md-9 col-lg-10 px-4 errorPage">
       <div className="container">
         <div className="page-title pt-5 pb-3">
-          <h3>Authorized MoTrPAC Consortia Members Only</h3>
+          <h3>Authorized MoTrPAC Members Only</h3>
         </div>
         <div className="contact-content-container">
-          <p className="alert alert-warning">
-            At this time, access to the MoTrPAC Data Hub data resources is limited
-            to Consortia members only. Please
-            {' '}
-            <ContactHelpdesk />
-            {' '}
-            and request access to the portal.
-          </p>
+          <div className="alert alert-warning">
+            <p>
+              You have reached this page because you are not identified as a
+              registered user in our system.
+            </p>
+            <p>
+              <i className="material-icons internal-icon">person</i>
+              <strong>MoTrPAC consortium members:</strong>
+              {' '}
+              If this is your first time attempting to log in, please
+              {' '}
+              <ContactHelpdesk />
+              {' '}
+              and verify your access to the portal.
+            </p>
+            <p>
+              <i className="material-icons external-icon">people_alt</i>
+              <strong>Users who are not MoTrPAC consortium members:</strong>
+              {' '}
+              To access the MoTrPAC Data Hub portal, please read and sign the data use
+              agreement, as well as complete the new user registration by visiting our
+              {' '}
+              <a href="/data-access">Data Access</a>
+              {' '}
+              page.
+            </p>
+          </div>
         </div>
       </div>
     </div>
@@ -49,10 +68,9 @@ ErrorPage.defaultProps = {
   isAuthenticated: false,
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   profile: state.auth.profile,
   isAuthenticated: state.auth.isAuthenticated,
 });
 
 export default connect(mapStateToProps)(ErrorPage);
-

--- a/src/LandingPage/landingPage.jsx
+++ b/src/LandingPage/landingPage.jsx
@@ -8,6 +8,7 @@ import LogoAnimation from '../assets/LandingPageGraphics/LogoAnimation_03082019-
 import LayerRunner from '../assets/LandingPageGraphics/Data_Layer_Runner.png';
 import HealthyHeart from '../assets/LandingPageGraphics/Infographic_Healthy_Heart.png';
 import ContactHelpdesk from '../lib/ui/contactHelpdesk';
+import ExternalLink from '../lib/ui/externalLink';
 
 // react-spring mouse parallax config
 const calc = (x, y) => [x - window.innerWidth / 2, y - window.innerHeight / 2];
@@ -83,26 +84,55 @@ export function LandingPage({ isAuthenticated, profile }) {
     setVisibility(!visibility);
   }
 
+  // Function to render webinar notice
+  const WebinarNotice = () => {
+    return (
+      <div className="alert alert-primary webinar-announce d-flex align-items-center justify-content-between w-100" role="alert">
+        <span className="webinar-announce-content">
+          <h6>
+            The Common Fund Molecular Transducers of Physical Activity (MoTrPAC) Program, through
+            its MoTrPAC Bioinformatics Center (BIC) will conduct a pre-application data Webinar
+            regarding Funding Opportunity Announcement (FOA) RFA-RM-20-009 on Thursday, February
+            13th at 1pm Eastern Standard Time. The webinar will provide background information
+            on MoTrPAC data that is available to the research community through its data
+            hub. Visit this
+            {' '}
+            <ExternalLink to="https://stanford.zoom.us/j/808358038" label="Zoom link" />
+            {' '}
+            to join the webinar.
+          </h6>
+        </span>
+      </div>
+    );
+  };
+
+  // Function to render external data release notice
+  const ExternalDataReleaseNotice = () => {
+    return (
+      <div className="alert alert-primary alert-dismissible fade show data-access-announce d-flex align-items-center justify-content-between w-100" role="alert">
+        <span className="data-access-announce-content">
+          <h5>
+            MoTrPAC data release 1.0 is now available! There is data from 5 different
+            tissues following an acute exercise bout in rats. Visit the
+            {' '}
+            <Link to="/data-access" className="inline-link">Data Access</Link>
+            {' '}
+            page to learn more and register for access.
+          </h5>
+        </span>
+        <button type="button" className="close" data-dismiss="alert" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+    );
+  };
+
   return (
     <div className="row marketing">
       <main>
         <div className="container hero h-100">
           <div className="row hero-wrapper h-100">
-            <div className="alert alert-primary alert-dismissible fade show data-access-announce d-flex align-items-center justify-content-between w-100" role="alert">
-              <span className="data-access-announce-content">
-                <h5>
-                  MoTrPAC data release 1.0 is now available! There is data from 5 different
-                  tissues following an acute exercise bout in rats. Visit the
-                  {' '}
-                  <Link to="/data-access" className="inline-link">Data Access</Link>
-                  {' '}
-                  page to learn more and register for access.
-                </h5>
-              </span>
-              <button type="button" className="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
+            <WebinarNotice />
             <div className="hero-image col-12 col-md-8 mx-auto">
               <img src={LogoAnimation} className="img-fluid" alt="Data Layer Runner" />
             </div>

--- a/src/LandingPage/landingPage.jsx
+++ b/src/LandingPage/landingPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Redirect, Link } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 import Particles from 'react-particles-js';
 import { useSpring, animated } from 'react-spring';
 import LogoAnimation from '../assets/LandingPageGraphics/LogoAnimation_03082019-yellow_pipelineball_left.gif';
@@ -102,27 +102,6 @@ export function LandingPage({ isAuthenticated, profile }) {
             to join the webinar.
           </h6>
         </span>
-      </div>
-    );
-  };
-
-  // Function to render external data release notice
-  const ExternalDataReleaseNotice = () => {
-    return (
-      <div className="alert alert-primary alert-dismissible fade show data-access-announce d-flex align-items-center justify-content-between w-100" role="alert">
-        <span className="data-access-announce-content">
-          <h5>
-            MoTrPAC data release 1.0 is now available! There is data from 5 different
-            tissues following an acute exercise bout in rats. Visit the
-            {' '}
-            <Link to="/data-access" className="inline-link">Data Access</Link>
-            {' '}
-            page to learn more and register for access.
-          </h5>
-        </span>
-        <button type="button" className="close" data-dismiss="alert" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
       </div>
     );
   };

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -307,7 +307,7 @@ function ReleaseEntry({ profile, currentView }) {
                     <div className="card-body">
                       <p className="release-description">{release.description}</p>
                       <p className="release-description file-extraction-instruction">
-                        All bundled datasets are compressed (*.tar.gz) and need to be extracted upon downloading. For MAC
+                        All bundled datasets are compressed (*.tar.gz) and need to be extracted upon downloading. For Mac
                         users, double-clicking a downloaded *.tar.gz file will extract it. For Windows users, use
                         {' '}
                         <ExternalLink to="https://www.winzip.com" label="WinZip" />

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -306,6 +306,18 @@ function ReleaseEntry({ profile, currentView }) {
                   <div className="card mb-3">
                     <div className="card-body">
                       <p className="release-description">{release.description}</p>
+                      <p className="release-description file-extraction-instruction">
+                        All bundled datasets are compressed (*.tar.gz) and need to be extracted upon downloading. For MAC
+                        users, double-clicking a downloaded *.tar.gz file will extract it. For Windows users, use
+                        {' '}
+                        <ExternalLink to="https://www.winzip.com" label="WinZip" />
+                        {' '}
+                        or
+                        {' '}
+                        <ExternalLink to="https://www.7-zip.org" label="7-Zip" />
+                        {' '}
+                        to extract the compressed file.
+                      </p>
                       {currentView === 'external'
                         ? (
                           <p className="release-description">

--- a/src/sass/_errorPage.scss
+++ b/src/sass/_errorPage.scss
@@ -1,0 +1,18 @@
+.errorPage {
+  .alert-warning {
+    p {
+      color: #856404;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+
+      .internal-icon,
+      .external-icon {
+        position: relative;
+        margin-right: 4px;
+        top: 5px;
+      }
+    }
+  }
+}

--- a/src/sass/_landingPage.scss
+++ b/src/sass/_landingPage.scss
@@ -43,6 +43,23 @@ main {
         }
       }
     }
+
+    .webinar-announce {
+      margin-bottom: 0;
+
+      .webinar-announce-content {
+        h6 {
+          font-weight: 600;
+          line-height: 1.6;
+          margin-top: 0.25rem;
+          margin-bottom: 0.25rem;
+
+          .inline-link-with-icon .material-icons {
+            font-size: 1.5rem;
+          }
+        }
+      }
+    }
   }
 }
 

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -15,6 +15,7 @@
 @import 'linkoutPage';
 @import 'analysisPage';
 @import 'teamPage';
+@import 'errorPage';
 @import 'downloads/all';
 @import 'methods';
 @import 'team';


### PR DESCRIPTION
**Key Changes:**
1. Added help text/link to instruct users on ways to extract downloaded files on the Release page.
2. Updated the Error page with instructions individually targeting consortium members and non-consortium users.
3. Replaced the external data release notice on the homepage temporarily with the upcoming webinar notice.
***
**Steps to test MOTR-201:**
1. Go to the homepage and expect to see the NIH-provided text for the webinar notice in place of the external data release notice.
***
**Steps to test MOTR-196:**
1. Sign into the data hub portal as either an internal or external user.
2. Expect to see the "All bundled datasets are compressed (*.tar.gz) and need to be extracted upon downloading..." text towards the top of the Release page.
***
**Steps to test MOTR-199:**
1. Sign out of the data hub portal.
2. Turn on the **MoTrPAC Data Hub** application's `google-oauth2` connection in Auth0's admin console.
3. Sign in with a Google account that has not been registered in Auth0.
4. Expect to see the new instruction text individually targeting the consortium and non-consortium users.