### PR TITLE
MOTR-209 Post-webinar updates

### DIFF
--- a/src/AnnouncementsPage/__tets__/announcementsPage.stories.jsx
+++ b/src/AnnouncementsPage/__tets__/announcementsPage.stories.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { AnnouncementsPage } from '../announcementsPage';
+import { Navbar } from '../../Navbar/navbar';
+import { Footer } from '../../Footer/footer';
+
+const testUser = require('../../testData/testUser');
+
+const navAction = {
+  logout: action('logging out'),
+};
+
+const footerAction = {
+  login: action('logging in'),
+};
+
+storiesOf('Announcements Page', module)
+  .addDecorator((story) => (
+    <>
+      <div className="App">
+        <header>
+          <Navbar isAuthenticated {...navAction} profile={testUser} />
+        </header>
+        <div className="row justify-content-center">
+          {story()}
+        </div>
+      </div>
+      <Footer isAuthenticated profile={testUser} {...footerAction} />
+    </>
+  ))
+  .add('Default', () => <AnnouncementsPage />);

--- a/src/AnnouncementsPage/announcements.json
+++ b/src/AnnouncementsPage/announcements.json
@@ -51,11 +51,11 @@
             },
             {
                 "label": "Webinar presentation slides",
-                "url": "http://study-docs.motrpac-data.org/MoTrPAC_BIC_Data_hub_webinar_20200213_slides.pdf"
+                "url": "http://study-docs.motrpac-data.org/MoTrPAC_BIC_Data_hub_webinar_slides.pdf"
             },
             {
                 "label": "Recorded webinar",
-                "url": "http://study-docs.motrpac-data.org/MoTrPAC_BIC_Data_hub_webinar_20200213_recording.mp4"
+                "url": "http://study-docs.motrpac-data.org/MoTrPAC_BIC_Data_hub_recorded_webinar.mp4"
             }
         ]
     }

--- a/src/AnnouncementsPage/announcements.json
+++ b/src/AnnouncementsPage/announcements.json
@@ -1,0 +1,62 @@
+[
+    {
+        "aid": 1,
+        "posted_date": "2019-10-15",
+        "title": "MoTrPAC data release 1.0 is here!",
+        "content": "The initial MoTrPAC dataset has become available to the community. There is data from 5 different tissues following an acute exercise bout in rats. Visit our Data Access page to learn more and register for access",
+        "metadata": {
+            "target": "external",
+            "tags": [
+                "release"
+            ],
+            "icon": "whatshot"
+        },
+        "links": [
+            {
+                "label": "Data Access",
+                "url": "/data-access"
+            }
+        ]
+    },
+    {
+        "aid": 2,
+        "posted_date": "2020-02-12",
+        "title": "Known issues with initial dataset",
+        "content": "The currently available animal dataset (Release 1.0) is not final. Specifically, data from more tissues will be added; and the current control dataset is limited in its coverage of fasting times and sacrifice time of day, which can confound the results when comparing to the exercised rats. Additional data will be made available in future releases.",
+        "metadata": {
+            "target": "external",
+            "tags": [
+                "dataset"
+            ],
+            "icon": "announcement"
+        },
+        "links": []
+    },
+    {
+        "aid": 3,
+        "posted_date": "2020-02-14",
+        "title": "Webinar regarding NIH funding opportunity announcement",
+        "content": "The Common Fund Molecular Transducers of Physical Activity (MoTrPAC) Program, through its MoTrPAC Bioinformatics Center (BIC) conducted a Pre-Application Webinar regarding a current Funding Opportunity Announcement (FOA) RFA-RM-20-009 on February 13, 2020. The webinar provided background information on MoTrPAC data that is available to the research community through its data hub. The presentation slides and recorded webinar are now available.",
+        "metadata": {
+            "target": "external",
+            "tags": [
+                "webinar"
+            ],
+            "icon": "movie"
+        },
+        "links": [
+            {
+                "label": "NIH Funding Opportunity Announcement",
+                "url": "https://grants.nih.gov/grants/guide/rfa-files/RFA-RM-20-009.html"
+            },
+            {
+                "label": "Webinar presentation slides",
+                "url": "http://study-docs.motrpac-data.org/MoTrPAC_BIC_Data_hub_webinar_20200213_slides.pdf"
+            },
+            {
+                "label": "Recorded webinar",
+                "url": "http://study-docs.motrpac-data.org/MoTrPAC_BIC_Data_hub_webinar_20200213_recording.mp4"
+            }
+        ]
+    }
+]

--- a/src/AnnouncementsPage/announcementsPage.jsx
+++ b/src/AnnouncementsPage/announcementsPage.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import ExternalLink from '../lib/ui/externalLink';
+
+/**
+ * Renders the External Links page in both
+ * unauthenticated and authenticated states.
+ *
+ * @param {Boolean} isAuthenticated Redux state for user's authentication status.
+ *
+ * @returns {Object} JSX representation of the External Links page.
+ */
+export function NewsPage({ isAuthenticated }) {
+  return (
+    <div className={`col-md-9 ${isAuthenticated ? 'ml-sm-auto' : ''} col-lg-10 px-4 announcementsPage`}>
+      <div className={`${!isAuthenticated ? 'container' : ''}`}>
+        <div className="page-title pt-3 pb-2 border-bottom">
+          <h3>Announcements</h3>
+        </div>
+        <div className="news-item-list">
+          {/* item-1 */}
+          <div className="d-flex align-items-start justify-content-start announcement-item">
+            <div className="announcement-item-icon">
+              <i className="material-icons announcement-icon webinar">movie</i>
+            </div>
+            <div className="flex-grow-1">
+              <div className="d-flex align-items-center justify-content-between announcement-header">
+                <h5 className="announcement-title">Webinar regarding NIH funding opportunity announcement</h5>
+                <div className="announcement-date">February 14, 2020</div>
+              </div>
+              <p className="announcement-content">
+                The Common Fund Molecular Transducers of Physical Activity (MoTrPAC) Program,
+                through its MoTrPAC Bioinformatics Center (BIC) conducted a Pre-Application
+                Webinar regarding a current
+                {' '}
+                <ExternalLink to="https://grants.nih.gov/grants/guide/rfa-files/RFA-RM-20-009.html" label="Funding Opportunity Announcement" />
+                {' '}
+                (FOA) RFA-RM-20-009 on February 13, 2020. The webinar provided background
+                information on MoTrPAC data that is available to the research community
+                through its data hub. The
+                {' '}
+                <Link to="/announcements" className="inline-link">presentation slides</Link>
+                {' '}
+                and
+                {' '}
+                <Link to="/announcements" className="inline-link">recorded webinar</Link>
+                {' '}
+                are now available.
+              </p>
+            </div>
+          </div>
+          {/* item-2 */}
+          <div className="d-flex align-items-start justify-content-start announcement-item">
+            <div className="announcement-item-icon">
+              <i className="material-icons announcement-icon control-data">announcement</i>
+            </div>
+            <div className="flex-grow-1">
+              <div className="d-flex align-items-center justify-content-between announcement-header">
+                <h5 className="announcement-title">Known issues with initial dataset</h5>
+                <div className="announcement-date">February 12, 2020</div>
+              </div>
+              <p className="announcement-content">
+                The currently available animal dataset (Release 1.0) is not final. Specifically, data
+                from more tissues will be added; and the current control dataset is limited in its
+                coverage of fasting times and sacrifice time of day, which can confound the results
+                when comparing to the exercised rats. Additional data will be made available in
+                future releases.
+              </p>
+            </div>
+          </div>
+          {/* item-3 */}
+          <div className="d-flex align-items-start justify-content-start announcement-item">
+            <div className="announcement-item-icon">
+              <i className="material-icons announcement-icon data-release">whatshot</i>
+            </div>
+            <div className="flex-grow-1">
+              <div className="d-flex align-items-center justify-content-between announcement-header">
+                <h5 className="announcement-title">MoTrPAC data release 1.0 is here!</h5>
+                <div className="announcement-date">October 16, 2019</div>
+              </div>
+              <p className="announcement-content">
+                The initial MoTrPAC dataset has become available to the community. There is data from 5
+                different tissues following an acute exercise bout in rats. Visit our
+                {' '}
+                <Link to="/data-access" className="inline-link">Data Access</Link>
+                {' '}
+                page to learn more and register for access.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+NewsPage.propTypes = {
+  isAuthenticated: PropTypes.bool,
+};
+
+NewsPage.defaultProps = {
+  isAuthenticated: false,
+};
+
+const mapStateToProps = (state) => ({
+  isAuthenticated: state.auth.isAuthenticated,
+});
+
+export default connect(mapStateToProps)(NewsPage);

--- a/src/AnnouncementsPage/announcementsPage.jsx
+++ b/src/AnnouncementsPage/announcementsPage.jsx
@@ -2,17 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import dayjs from 'dayjs';
 import ExternalLink from '../lib/ui/externalLink';
 
+const announcements = require('./announcements');
+
 /**
- * Renders the External Links page in both
+ * Renders the Announcements page in both
  * unauthenticated and authenticated states.
  *
  * @param {Boolean} isAuthenticated Redux state for user's authentication status.
  *
- * @returns {Object} JSX representation of the External Links page.
+ * @returns {Object} JSX representation of the Announcements page.
  */
-export function NewsPage({ isAuthenticated }) {
+export function AnnouncementsPage({ isAuthenticated }) {
   return (
     <div className={`col-md-9 ${isAuthenticated ? 'ml-sm-auto' : ''} col-lg-10 px-4 announcementsPage`}>
       <div className={`${!isAuthenticated ? 'container' : ''}`}>
@@ -20,87 +23,78 @@ export function NewsPage({ isAuthenticated }) {
           <h3>Announcements</h3>
         </div>
         <div className="news-item-list">
-          {/* item-1 */}
-          <div className="d-flex align-items-start justify-content-start announcement-item">
-            <div className="announcement-item-icon">
-              <i className="material-icons announcement-icon webinar">movie</i>
-            </div>
-            <div className="flex-grow-1">
-              <div className="d-flex align-items-center justify-content-between announcement-header">
-                <h5 className="announcement-title">Webinar regarding NIH funding opportunity announcement</h5>
-                <div className="announcement-date">February 14, 2020</div>
-              </div>
-              <p className="announcement-content">
-                The Common Fund Molecular Transducers of Physical Activity (MoTrPAC) Program,
-                through its MoTrPAC Bioinformatics Center (BIC) conducted a Pre-Application
-                Webinar regarding a current
-                {' '}
-                <ExternalLink to="https://grants.nih.gov/grants/guide/rfa-files/RFA-RM-20-009.html" label="Funding Opportunity Announcement" />
-                {' '}
-                (FOA) RFA-RM-20-009 on February 13, 2020. The webinar provided background
-                information on MoTrPAC data that is available to the research community
-                through its data hub. The
-                {' '}
-                <Link to="/announcements" className="inline-link">presentation slides</Link>
-                {' '}
-                and
-                {' '}
-                <Link to="/announcements" className="inline-link">recorded webinar</Link>
-                {' '}
-                are now available.
-              </p>
-            </div>
-          </div>
-          {/* item-2 */}
-          <div className="d-flex align-items-start justify-content-start announcement-item">
-            <div className="announcement-item-icon">
-              <i className="material-icons announcement-icon control-data">announcement</i>
-            </div>
-            <div className="flex-grow-1">
-              <div className="d-flex align-items-center justify-content-between announcement-header">
-                <h5 className="announcement-title">Known issues with initial dataset</h5>
-                <div className="announcement-date">February 12, 2020</div>
-              </div>
-              <p className="announcement-content">
-                The currently available animal dataset (Release 1.0) is not final. Specifically, data
-                from more tissues will be added; and the current control dataset is limited in its
-                coverage of fasting times and sacrifice time of day, which can confound the results
-                when comparing to the exercised rats. Additional data will be made available in
-                future releases.
-              </p>
-            </div>
-          </div>
-          {/* item-3 */}
-          <div className="d-flex align-items-start justify-content-start announcement-item">
-            <div className="announcement-item-icon">
-              <i className="material-icons announcement-icon data-release">whatshot</i>
-            </div>
-            <div className="flex-grow-1">
-              <div className="d-flex align-items-center justify-content-between announcement-header">
-                <h5 className="announcement-title">MoTrPAC data release 1.0 is here!</h5>
-                <div className="announcement-date">October 16, 2019</div>
-              </div>
-              <p className="announcement-content">
-                The initial MoTrPAC dataset has become available to the community. There is data from 5
-                different tissues following an acute exercise bout in rats. Visit our
-                {' '}
-                <Link to="/data-access" className="inline-link">Data Access</Link>
-                {' '}
-                page to learn more and register for access.
-              </p>
-            </div>
-          </div>
+          {
+            announcements.reverse().map((entry) => <AnnouncementEntry entry={entry} />)
+          }
         </div>
       </div>
     </div>
   );
 }
 
-NewsPage.propTypes = {
+// Render individual announcement entry
+function AnnouncementEntry({ entry }) {
+  return (
+    <div key={entry.aid} className="d-flex align-items-start justify-content-start announcement-item">
+      <div className="announcement-item-icon">
+        <i className={`material-icons announcement-icon ${entry.metadata.tags[0]}`}>{entry.metadata.icon}</i>
+      </div>
+      <div className="flex-grow-1">
+        <div className="d-flex align-items-center justify-content-between announcement-header">
+          <h5 className="announcement-title">{entry.title}</h5>
+          <div className="announcement-date">{dayjs(entry.posted_date).format('MMMM D, YYYY')}</div>
+        </div>
+        <p className="announcement-content">{entry.content}</p>
+        {entry.links && entry.links.length
+          ? (
+            <ul className="announcement-links">
+              {entry.links.map((link) => (
+                <li key={link.url} className="announcement-link-item">
+                  {
+                    link.url.indexOf('http') > -1 ? (
+                      <ExternalLink to={link.url} label={link.label} />
+                    ) : (
+                      <Link to={link.url} className="inline-link inline-link-with-icon">
+                        {link.label}
+                        <i className="material-icons internal-link">link</i>
+                      </Link>
+                    )
+                  }
+                </li>
+              ))}
+            </ul>
+          )
+          : null}
+      </div>
+    </div>
+  );
+}
+
+const linksPropType = {
+  label: PropTypes.string,
+  url: PropTypes.string,
+};
+
+AnnouncementEntry.propTypes = {
+  entry: PropTypes.shape({
+    aid: PropTypes.number.isRequired,
+    posted_date: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    content: PropTypes.string.isRequired,
+    metadata: PropTypes.shape({
+      target: PropTypes.string.isRequired,
+      tags: PropTypes.array.isRequired,
+      icon: PropTypes.string.isRequired,
+    }).isRequired,
+    links: PropTypes.arrayOf(PropTypes.shape({ ...linksPropType })),
+  }).isRequired,
+};
+
+AnnouncementsPage.propTypes = {
   isAuthenticated: PropTypes.bool,
 };
 
-NewsPage.defaultProps = {
+AnnouncementsPage.defaultProps = {
   isAuthenticated: false,
 };
 
@@ -108,4 +102,4 @@ const mapStateToProps = (state) => ({
   isAuthenticated: state.auth.isAuthenticated,
 });
 
-export default connect(mapStateToProps)(NewsPage);
+export default connect(mapStateToProps)(AnnouncementsPage);

--- a/src/AnnouncementsPage/announcementsPage.jsx
+++ b/src/AnnouncementsPage/announcementsPage.jsx
@@ -5,7 +5,9 @@ import { Link } from 'react-router-dom';
 import dayjs from 'dayjs';
 import ExternalLink from '../lib/ui/externalLink';
 
-const announcements = require('./announcements');
+const announcementData = require('./announcements');
+// Pre-sort array in reverse order to workaround Storybook issue
+const announcements = announcementData.reverse();
 
 /**
  * Renders the Announcements page in both
@@ -24,7 +26,7 @@ export function AnnouncementsPage({ isAuthenticated }) {
         </div>
         <div className="news-item-list">
           {
-            announcements.reverse().map((entry) => <AnnouncementEntry entry={entry} />)
+            announcements.map((entry) => <AnnouncementEntry entry={entry} />)
           }
         </div>
       </div>

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -20,6 +20,7 @@ import SearchPageConnected from '../Search/searchPage';
 import ReleasePageConnected from '../ReleasePage/releasePage';
 import DataSummaryPageConnected from '../DataSummaryPage/dataSummaryPage';
 import DataAccessPageConnected from '../DataAccess/dataAccessPage';
+import AnnouncementsPageConnected from '../AnnouncementsPage/announcementsPage';
 import CallbackConnected from '../Auth/callback';
 import SidebarConnected from '../Sidebar/sidebar';
 import { withTracker } from '../GoogleAnalytics/googleAnalytics';
@@ -47,6 +48,7 @@ function App({ history = History }) {
               <Route path="/methods" component={withTracker(MethodsConnected)} />
               <Route path="/team" component={withTracker(TeamPageConnected)} />
               <Route path="/contact" component={withTracker(ContactConnected)} />
+              <Route path="/announcements" component={withTracker(AnnouncementsPageConnected)} />
               <Route path="/error" component={withTracker(ErrorPageConnected)} />
               <Route path="/search" component={withTracker(SearchPageConnected)} />
               <Route path="/summary" component={withTracker(DataSummaryPageConnected)} />

--- a/src/LandingPage/landingPage.jsx
+++ b/src/LandingPage/landingPage.jsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Redirect } from 'react-router-dom';
+import { Redirect, Link } from 'react-router-dom';
 import Particles from 'react-particles-js';
 import { useSpring, animated } from 'react-spring';
 import LogoAnimation from '../assets/LandingPageGraphics/LogoAnimation_03082019-yellow_pipelineball_left.gif';
 import LayerRunner from '../assets/LandingPageGraphics/Data_Layer_Runner.png';
 import HealthyHeart from '../assets/LandingPageGraphics/Infographic_Healthy_Heart.png';
 import ContactHelpdesk from '../lib/ui/contactHelpdesk';
-import ExternalLink from '../lib/ui/externalLink';
 
 // react-spring mouse parallax config
 const calc = (x, y) => [x - window.innerWidth / 2, y - window.innerHeight / 2];
@@ -84,34 +83,38 @@ export function LandingPage({ isAuthenticated, profile }) {
     setVisibility(!visibility);
   }
 
-  // Function to render webinar notice
-  const WebinarNotice = () => {
-    return (
-      <div className="alert alert-primary webinar-announce d-flex align-items-center justify-content-between w-100" role="alert">
-        <span className="webinar-announce-content">
-          <h6>
-            The Common Fund Molecular Transducers of Physical Activity (MoTrPAC) Program, through
-            its MoTrPAC Bioinformatics Center (BIC) will conduct a pre-application data Webinar
-            regarding Funding Opportunity Announcement (FOA) RFA-RM-20-009 on Thursday, February
-            13th at 1pm Eastern Standard Time. The webinar will provide background information
-            on MoTrPAC data that is available to the research community through its data
-            hub. Visit this
-            {' '}
-            <ExternalLink to="https://stanford.zoom.us/j/808358038" label="Zoom link" />
-            {' '}
-            to join the webinar.
-          </h6>
-        </span>
-      </div>
-    );
-  };
+  // Function to render external data release notice
+  const ExternalDataReleaseNotice = () => (
+    <div className="alert alert-primary alert-dismissible fade show data-access-announce d-flex align-items-center justify-content-between w-100" role="alert">
+      <span className="data-access-announce-content">
+        <h6>
+          MoTrPAC data release 1.0 is now available! There is data from 5 different
+          tissues following an acute exercise bout in rats. Visit the
+          {' '}
+          <Link to="/data-access" className="inline-link">Data Access</Link>
+          {' '}
+          page to learn more and register for access.
+        </h6>
+        <h6>
+          Additional control time point data will be released soon.
+          {' '}
+          <Link to="/news" className="inline-link">Read more</Link>
+          {' '}
+          about it.
+        </h6>
+      </span>
+      <button type="button" className="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+  );
 
   return (
     <div className="row marketing">
       <main>
         <div className="container hero h-100">
           <div className="row hero-wrapper h-100">
-            <WebinarNotice />
+            <ExternalDataReleaseNotice />
             <div className="hero-image col-12 col-md-8 mx-auto">
               <img src={LogoAnimation} className="img-fluid" alt="Data Layer Runner" />
             </div>

--- a/src/LandingPage/landingPage.jsx
+++ b/src/LandingPage/landingPage.jsx
@@ -8,6 +8,7 @@ import LogoAnimation from '../assets/LandingPageGraphics/LogoAnimation_03082019-
 import LayerRunner from '../assets/LandingPageGraphics/Data_Layer_Runner.png';
 import HealthyHeart from '../assets/LandingPageGraphics/Infographic_Healthy_Heart.png';
 import ContactHelpdesk from '../lib/ui/contactHelpdesk';
+import ExternalLink from '../lib/ui/externalLink';
 
 // react-spring mouse parallax config
 const calc = (x, y) => [x - window.innerWidth / 2, y - window.innerHeight / 2];
@@ -95,15 +96,15 @@ export function LandingPage({ isAuthenticated, profile }) {
           {' '}
           page to learn more and register for access.
         </h6>
-        <p>
-          <strong>Please note:</strong>
+        <h6>
+          <Link to="/announcements" className="inline-link">Find out more</Link>
           {' '}
-          The currently available animal dataset (Release 1.0) is not final. Specifically, data
-          from more tissues will be added; and the current control dataset is limited in its
-          coverage of fasting times and sacrifice time of day, which can confound the results
-          when comparing to the exercised rats. Additional data will be made available in
-          future releases.
-        </p>
+          about MoTrPAC's recent Pre-Application Webinar regarding a current
+          {' '}
+          <ExternalLink to="https://grants.nih.gov/grants/guide/rfa-files/RFA-RM-20-009.html" label="Funding Opportunity Announcement" />
+          {' '}
+          and updates on known issues with the initial dataset.
+        </h6>
       </span>
       <button type="button" className="close" data-dismiss="alert" aria-label="Close">
         <span aria-hidden="true">&times;</span>

--- a/src/Navbar/navbar.jsx
+++ b/src/Navbar/navbar.jsx
@@ -84,6 +84,7 @@ export function Navbar({
               <li className="nav-item navItem dropdown">
                 <div className="nav-link dropdown-toggle" role="button" id="navbarDropdownMenuLink" data-toggle="dropdown">About Us</div>
                 <div className="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                  <Link to="/announcements" className="dropdown-item">Announcements</Link>
                   <Link to="/external-links" className="dropdown-item">Useful Links</Link>
                   <Link to="/team" className="dropdown-item">Who we are</Link>
                   <Link to="/contact" className="dropdown-item">Contact Us</Link>

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { TrackEvent } from '../GoogleAnalytics/googleAnalytics';
 import IconSet from '../lib/iconSet';
@@ -344,8 +345,11 @@ function ReleaseEntry({ profile, currentView }) {
                         </a>
                         {' '}
                         document has been provided detailing the different data types available
-                        in this release in addition to how to access them. For any technical
-                        issues, please contact us at
+                        in this release in addition to how to access them. For updates on known
+                        issues with the initial dataset, please see our
+                        {' '}
+                        <Link to="/announcements" className="inline-link">recent announcement</Link>
+                        . For any technical issues, please contact us at
                         {' '}
                         <EmailLink mailto="motrpac-helpdesk@lists.stanford.edu" label="MoTrPAC Helpdesk" />
                       </p>

--- a/src/sass/_announcementsPage.scss
+++ b/src/sass/_announcementsPage.scss
@@ -28,11 +28,11 @@
       color: $accent-green;
     }
 
-    &.control-data {
+    &.dataset {
       color: $accent-yellow;
     }
 
-    &.data-release {
+    &.release {
       color: $stanford-bright-red;
     }
   }
@@ -54,9 +54,20 @@
 
   .announcement-content {
     line-height: 1.6;
+  }
 
-    .inline-link-with-icon .material-icons {
-      margin-top: 0.125rem;
+  .announcement-links {
+    font-size: 0.85rem;
+    list-style: none;
+    margin: 0 0 1.0rem 0;
+    padding: 0;
+
+    .announcement-link-item {
+      line-height: 1.6;
+
+      .inline-link-with-icon .material-icons {
+        margin-top: 0.125rem;
+      }
     }
   }
 }

--- a/src/sass/_announcementsPage.scss
+++ b/src/sass/_announcementsPage.scss
@@ -1,0 +1,63 @@
+.announcementsPage {
+  .page-title {
+    margin-bottom: 1.5rem;
+
+    h3 {
+      margin-bottom: 0;
+    }
+  }
+
+  .announcement-item {
+    border-top: 1px solid $gray-transparent;
+    margin-top: 0.65rem;
+    padding-top: 1.5rem;
+
+    &:first-child {
+      border-top: none;
+      margin-top: 0;
+      padding-top: 0;
+    }
+  }
+
+  .announcement-icon {
+    font-size: 72px;
+    margin-left: 36px;
+    margin-right: 64px;
+
+    &.webinar {
+      color: $accent-green;
+    }
+
+    &.control-data {
+      color: $accent-yellow;
+    }
+
+    &.data-release {
+      color: $stanford-bright-red;
+    }
+  }
+
+  .announcement-header {
+    margin-bottom: 0.5rem;
+  }
+
+  .announcement-title {
+    margin-bottom: 0;
+  }
+
+  .announcement-date {
+    color: $gray-semi-transparent;
+    font-size: 0.85rem;
+    min-width: 125px;
+    text-align: right;
+  }
+
+  .announcement-content {
+    line-height: 1.6;
+
+    .inline-link-with-icon .material-icons {
+      margin-top: 0.125rem;
+    }
+  }
+}
+

--- a/src/sass/_landingPage.scss
+++ b/src/sass/_landingPage.scss
@@ -5,7 +5,7 @@
 
 main {
   width: 100%;
-  height: 40.5rem;
+  height: 39.5rem;
   overflow: hidden;
 
   .hero-wrapper {
@@ -40,31 +40,16 @@ main {
           font-weight: 600;
           line-height: 1.6;
           margin-top: 0.25rem;
-          margin-bottom: 0.25rem;
-
-          .inline-link-with-icon .material-icons {
-            font-size: 1.5rem;
-          }
-        }
-      }
-    }
-
-    .webinar-announce {
-      margin-bottom: 0;
-
-      .webinar-announce-content {
-        p {
-          line-height: 1.5;
-          margin-top: 0.25rem;
-          margin-bottom: 0.25rem;
+          margin-bottom: 0.6rem;
 
           .inline-link-with-icon .material-icons {
             font-size: 1.25rem;
+            margin-top: 0.2rem;
           }
         }
 
-        p:first-child {
-          margin-bottom: 10px;
+        h6:last-child {
+          margin-bottom: 0.25rem;
         }
       }
     }

--- a/src/sass/_landingPage.scss
+++ b/src/sass/_landingPage.scss
@@ -36,10 +36,15 @@ main {
       margin-bottom: 0;
 
       .data-access-announce-content {
-        h5 {
-          line-height: 1.5;
+        h6 {
+          font-weight: 600;
+          line-height: 1.6;
           margin-top: 0.25rem;
           margin-bottom: 0.25rem;
+
+          .inline-link-with-icon .material-icons {
+            font-size: 1.5rem;
+          }
         }
       }
     }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -28,3 +28,4 @@
 @import 'dataAccess/all';
 @import 'studyDocumentTable';
 @import 'links';
+@import 'announcementsPage';


### PR DESCRIPTION
**Key Changes:**
1. Homepage
    * Replaced temporary webinar announcement content with original external data release announcement content in blue alert box.
    * Added announcement content about RFA and control issues in initial dataset.
2. Release page
    * Added language about initial dataset's control issues in the same paragraph of README.
3. Announcements page
    * Newly created and accessible in the **About Us** dropdown menu.
    * Added 3 announcement items - webinar with links to the recorded video and slide deck, NIH RFA, and external data release.